### PR TITLE
Improve case-insensitivity and alternate args

### DIFF
--- a/aegis.bas
+++ b/aegis.bas
@@ -1,4 +1,4 @@
-
+'
 ' MIT License                                               _______________      
 '                                                           \......|....../      
 ' Name:           AEGIS - Plaintext Encryption Utility       \ A E G I S /       

--- a/aegis.bas
+++ b/aegis.bas
@@ -101,7 +101,7 @@
 
     115 'COMMANDS
            argv$(1) = th_sed$( argv$(1), "^(-?-|/)" )
-        if argv$(1) = "es" or argv$(1) = "se" and argv$(2) <> "" then to$ = argv$(2) : goto 190
+        if ups$( argv$(1) ) = "ES" or ups$( argv$(1) ) = "SE" and argv$(2) <> "" then to$ = argv$(2) : send_now = 1 : goto 190
         if th_re( ups$( argv$(1) ), "^S(END)?$" ) and argv$(2) <> "" and argv$(3) <> "" then to$ = argv$(3) : goto 240
         if th_re( ups$( argv$(1) ), "^E(NCRYPT)?$" ) then goto 190
         if th_re( ups$( argv$(1) ), "^D(ECRYPT)?$" ) and argv$(2) <> "" then ef$ = argv$(2) : goto 142
@@ -278,7 +278,7 @@
             gosub 120
 
     200 'FILE OUTPUT FUNCTIONS
-            if argv$(1) <> "e" then goto 201
+            if ups$( argv$(1) ) <> "E" then goto 201
             ? : ? "Save cipher and key separately? (y/N)" ;
             keychoice$ = inkey$
             if keychoice$ = "y" then goto 250
@@ -286,7 +286,7 @@
             ?# 1, encryptedmsg$ + "l" + otp$ + " "
             close #1
             ? : th_exec "ls " + file$ + ".ags"
-            if argv$(1) = "es" then now$ = "y" : goto 203
+            if send_now then now$ = "y" : goto 203
             ? "Send now? [y/N] " ; : now$ = inkey$ : ? now$ : if now$ = "y" then goto 202
             goto 9999
         202 input "To: ", to$ : if to$ = user$ then ? "You cannot send a file to yourself! Select another user." : goto 202


### PR DESCRIPTION
Made it so that using `-se` instead of `-es` actually works, also made `-es` and `-se` case-insensitive because I hadn't before; and added a lil' comment tick at the beginning of the file because I didn't like the look of the blank line just sitting at the top.  