### PR TITLE
chomp input statements so leading trailing spaces don't break things

### DIFF
--- a/aegis.bas
+++ b/aegis.bas
@@ -31,6 +31,7 @@
 ' AND HE WILL ADD YOU TO THE REPO, WHERE YOU CAN CREATE A PULL REQUEST
     
     10  ver$ = "2.2.1"
+        def fnChomp$( s$ ) = th_sed$( s$, "^\s+|\s+$" )
 
         ' GLOBAL SETTINGS (set to 1 to enable)
 
@@ -57,7 +58,7 @@
         END
 
     40  ?
-        ? " AEGIS v" ver$ " Encryption Utility for TELEHACK                   "
+        ? " AEGIS v" + ver$ + " Encryption Utility for TELEHACK               "
         ? "                                                                   "
         ? " %usage: aegis <function> [filename] [sender/receipient]           "
         ? "         prefix all functions with -, --, /, or nothing at all     "
@@ -150,8 +151,8 @@
     140 ' DECRYPT
 
         ' READ DATA FROM FILE AND PUT IT IN CULL$
-        141 ? : input "Filename: ", ef$
-        142 if ef$ = "" or ef$ = spc$(len(ef$)) then ? "%error - blank filename" : goto 141
+        141 ? : ? "Filename: "; : ef$ = fnChomp$( input$ )
+        142 if ef$ = "" then ? "%error - blank filename" : goto 141
             open ef$ + ".ags", as #1
             fatalerroronedebug$ = ef$ + ".ags"
         143 if typ(1) = 3 then goto 144
@@ -277,9 +278,9 @@
         goto 9999
 
     181 ' VISIBLE MESSAGE INPUT AND FILE NAMING     
-        182 input "Message: ", msg$
+        182 ? "Message: "; : msg$ = fnChomp$( input$ )
             if msg$ = "" then goto 182
-        183 input "Filename: ", file$
+        183 ? "Filename: "; : file$ = fnChomp$( input$ )
             if file$ = "" then goto 183
             if len(file$) < 1 then goto 183
             if len(file$) > 3 then ? : ? "Filename must not exceed 3 characters" : goto 183
@@ -319,7 +320,7 @@
             if send_now then now$ = "y" : goto 203
             ? "Send now? [y/N] " ; : now$ = inkey$ : ? now$ : if now$ = "y" then goto 202
             goto 9999
-        202 input "To: ", to$ : if to$ = "" then ? "You must select a user!" : goto 202 : if to$ = user$ then ? "You cannot send a file to yourself! Select another user." : goto 202
+        202 ? "To: "; : to$ = fnChomp$( input$ ) : if to$ = "" then ? "You must select a user!" : goto 202 : if to$ = user$ then ? "You cannot send a file to yourself! Select another user." : goto 202
         203 if to$ = user$ then ? "You cannot send a file to yourself! Select another user." : goto 202
         204 th_exec "send /bell /attach=" + file$ + ".ags " + to$
             ? "[R]esend if the file transfer fails." : ? "[D]elete file, cancel send, and close program." :  ? "^C to close. Request to send will persist." : if inkey$ <> "d" then goto 204


### PR DESCRIPTION
Also added a `+` during a concatenation because they're used everywhere else in the file.  